### PR TITLE
npmのユーザー名をpkg名に利用

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sadness.ojisan/yarakasanai",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "src/main.js",
   "repository": "https://github.com/sadnessOjisan/yarakasanai.git",
   "author": "sadness_ojisan <sadness.ojisan@gmail.com>",


### PR DESCRIPTION
## 概要

npmのユーザー名をpkg名に利用

## 変更点

- npmのユーザー名をpkg名に利用する。どうやら一致しないとscoped modlueとしてpublishできない模様