### PR TITLE
moduleのentry pointを設定 + α

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sadness.ojisan/yarakasanai",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "dist/bundle.js",
   "repository": "https://github.com/sadnessOjisan/yarakasanai.git",
   "author": "sadness_ojisan <sadness.ojisan@gmail.com>",


### PR DESCRIPTION
## 概要

moduleのentry pointを設定し、publishするfileを指定

## 変更点

- dist/bundle.jsをentry pointに指定
- 余計なファイルをpublishしないようにpkg.jsonで指定